### PR TITLE
Add licence key for tinyeditor if you have

### DIFF
--- a/config/filament-tinyeditor.php
+++ b/config/filament-tinyeditor.php
@@ -7,6 +7,7 @@ return [
             'version' => '23.10.9',
             'package' => 'langs6',
         ],
+        'licence_key' => env('TINY_LICENSE_KEY', 'no-api-key'),
     ],
     'provider' => 'cloud', // cloud|vendor
     // 'direction' => 'rtl',

--- a/src/TinyeditorServiceProvider.php
+++ b/src/TinyeditorServiceProvider.php
@@ -33,6 +33,8 @@ class TinyeditorServiceProvider extends PackageServiceProvider
     {
         $tinyVersion = config('filament-tinyeditor.version.tiny', '6.7.1');
 
+        $tiny_licence_key = config('filament-tinyeditor.version.licence_key', 'no-api-key');
+
         $tiny_languages = Tiny::getLanguages();
 
         $languages = [];
@@ -52,6 +54,11 @@ class TinyeditorServiceProvider extends PackageServiceProvider
         $provider = config('filament-tinyeditor.provider', 'cloud');
 
         $mainJs = 'https://cdn.jsdelivr.net/npm/tinymce@'.$tinyVersion.'/tinymce.js';
+
+        if ($tiny_licence_key != 'no-api-key') {
+            $mainJs = 'https://cdn.tiny.cloud/1/'.$tiny_licence_key.'/tinymce/'.$tinyVersion.'/tinymce.min.js';
+        }
+
         if ($provider == 'vendor') {
             $mainJs = asset('vendor/tinymce/tinymce.min.js');
         }


### PR DESCRIPTION
For this pull request, the possibility of adding the license key and downloading the JS file from the cloud has been added, to use Tiny's tools with premium features.

Remember to add the env key like this.

`TINY_LICENSE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`