### PR TITLE
Add default value to getCustomConfigs method

### DIFF
--- a/src/TinyEditor.php
+++ b/src/TinyEditor.php
@@ -308,7 +308,7 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained, Cont
             return str_replace('"', "'", json_encode(config('filament-tinyeditor.profiles.' . $this->profile . '.custom_configs')));
         }
 
-        return '';
+        return '{}';
     }
 
     public function darkMode(): string | bool


### PR DESCRIPTION
Without custom configs defined in the configuration file, and the default value set to `""`, the editor does not renders, and the following error appears in the console:
![image](https://github.com/amidesfahani/filament-tinyeditor/assets/166022255/ea99d0dd-0e5f-4000-bdda-fe526fe1f8ec)

After adding an empty json `{}` as the default value, the issue seems to be fixed.