### PR TITLE
Updated async script loading to AsyncAlpine v2

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -7,8 +7,8 @@
         $textareaID = 'tiny-editor-' . str_replace(['.', '#', '$'], '-', $getId()) . '-' . rand();
     @endphp
 
-    <div wire:ignore x-ignore ax-load
-        ax-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('tinyeditor', 'amidesfahani/filament-tinyeditor') }}"
+    <div wire:ignore x-ignore x-load
+        x-load-src="{{ \Filament\Support\Facades\FilamentAsset::getAlpineComponentSrc('tinyeditor', 'amidesfahani/filament-tinyeditor') }}"
         x-load-css="[@js(\Filament\Support\Facades\FilamentAsset::getStyleHref('tiny-css', package: 'amidesfahani/filament-tinyeditor'))]"
         x-load-js="[@js(\Filament\Support\Facades\FilamentAsset::getScriptSrc($getLanguageId(), package: 'amidesfahani/filament-tinyeditor'))]"
         x-data="tinyeditor({


### PR DESCRIPTION
This commit on Filament https://github.com/filamentphp/filament/commit/af36dec35113be5747e12f013dd288d7287ce533 upgraded AsyncAlpine from v1 to v2, which has a major breaking change (https://async-alpine.dev/docs/upgrade). The attributes ax-load and ax-load-src dropped the "a" and now are called x-load and x-load-src.

