### PR TITLE
Fix Livewire state sync issue when TinyEditor is loaded dynamically

### DIFF
--- a/resources/views/tiny-editor.blade.php
+++ b/resources/views/tiny-editor.blade.php
@@ -81,6 +81,11 @@
                     custom_configs: {{ $getCustomConfigs() }},
                     uploadingMessage: '{{ $getUploadingMessage() ?: 'Uploading image...' }}',
                     key: '{{ $getKey() }}',
+                    setup: (editor) => {
+                        editor.on('blur change keyup', () => {
+                            $wire.set('{{ $statePath }}', editor.getContent())
+                        })
+                    },
                 })" wire:ignore
                 wire:key="{{ $livewireKey }}.{{ substr(md5(serialize([$isDisabled])), 0, 64) }}">
                 @if ($isDisabled)


### PR DESCRIPTION
This PR fixes an issue where TinyEditor fields loaded dynamically (e.g., inside modals, repeaters, or step components) in Filament v4 were not syncing their content with Livewire. As a result, validation incorrectly detected the field as empty even when text was entered.

The issue was caused by missing Livewire state updates after user input when the editor was initialized dynamically via `x-load`. A manual `$wire.set()` call was added inside the TinyMCE `setup` callback to ensure proper synchronization between the editor content and Livewire state on `blur`, `change`, and `keyup` events.

**Summary of changes:**

* Added explicit Livewire state update in TinyMCE `setup`:

  ```js
  editor.on('blur change keyup', () => {
      $wire.set('{{ $statePath }}', editor.getContent())
  })
  ```
* Ensures proper content persistence and validation when the editor is used in dynamic contexts (modals, repeaters, etc.).