### PR TITLE
Validate uploaded file attachments are images

### DIFF
--- a/src/TinyEditor.php
+++ b/src/TinyEditor.php
@@ -119,11 +119,25 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained
                     $attachment = $this->getUploadedFileAttachment($fileKey);
 
                     if ($attachment) {
-                        if (! str_starts_with($attachment->getMimeType(), 'image/')) {
+                        // getMimeType() can return null when the MIME type cannot be
+                        // determined; normalise to an empty string to avoid a TypeError
+                        // in str_starts_with().
+                        $mimeType = $attachment->getMimeType() ?? '';
+                        if (! str_starts_with($mimeType, 'image/')) {
                             continue;
                         }
 
-                        if (! getimagesize($attachment->getRealPath())) {
+                        // getRealPath() returns false for stream wrappers or missing
+                        // temp files.  Read the file contents instead and validate the
+                        // image data with getimagesizefromstring(), which is also free
+                        // of the PHP warnings that getimagesize() emits on bad input.
+                        $realPath = $attachment->getRealPath();
+                        if (! is_string($realPath) || $realPath === '') {
+                            continue;
+                        }
+
+                        $fileContents = @file_get_contents($realPath);
+                        if ($fileContents === false || ! @getimagesizefromstring($fileContents)) {
                             continue;
                         }
 
@@ -185,7 +199,7 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function getToolbar(): string
     {
-        $toolbar = 'undo redo removeformat | styles | bold italic | rtl ltr | alignjustify alignright aligncenter alignleft | numlist bullist outdent indent accordion | forecolor backcolor | blockquote table toc hr | image link anchor media codesample emoticons | visualblocks print preview wordcount fullscreen help';
+        $toolbar = 'undo redo removeformat | styles | bold italic | rtl ltr | alignjustify alignright aligncenter alignleft | numlist bullist outdent indent accordion | forecolor backcolor | blockquote | link anchor codesample | image media | table | charmap emoticons hr | pagebreak nonbreaking | visualblocks visualchars | code wordcount | fullscreen preview print';
         if ($this->isSimple()) {
             $toolbar = 'removeformat | bold italic | rtl ltr | link emoticons';
         }
@@ -219,7 +233,7 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function getPlugins(): string
     {
-        $plugins = 'accordion autoresize codesample directionality advlist autolink link image lists charmap preview anchor pagebreak searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media table emoticons help';
+        $plugins = 'accordion autoresize codesample directionality advlist autolink link image lists charmap preview anchor pagebreak searchreplace wordcount visualblocks visualchars code fullscreen media table emoticons hr nonbreaking';
 
         if ($this->isSimple()) {
             $plugins = 'autoresize directionality emoticons link wordcount';

--- a/src/TinyEditor.php
+++ b/src/TinyEditor.php
@@ -119,6 +119,14 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained
                     $attachment = $this->getUploadedFileAttachment($fileKey);
 
                     if ($attachment) {
+                        if (! str_starts_with($attachment->getMimeType(), 'image/')) {
+                            continue;
+                        }
+
+                        if (! getimagesize($attachment->getRealPath())) {
+                            continue;
+                        }
+
                         $nodeAttrsId = $component->saveUploadedFileAttachment($attachment);
                         $nodeAttrsSrc = $component->getFileAttachmentUrl($nodeAttrsId);
 

--- a/src/TinyEditor.php
+++ b/src/TinyEditor.php
@@ -128,16 +128,15 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained
                         }
 
                         // getRealPath() returns false for stream wrappers or missing
-                        // temp files.  Read the file contents instead and validate the
-                        // image data with getimagesizefromstring(), which is also free
-                        // of the PHP warnings that getimagesize() emits on bad input.
+                        // temp files. When a real local path is available, validate the
+                        // image directly from disk to avoid reading the entire upload
+                        // into memory first; suppress warnings on invalid image data.
                         $realPath = $attachment->getRealPath();
                         if (! is_string($realPath) || $realPath === '') {
                             continue;
                         }
 
-                        $fileContents = @file_get_contents($realPath);
-                        if ($fileContents === false || ! @getimagesizefromstring($fileContents)) {
+                        if (! @getimagesize($realPath)) {
                             continue;
                         }
 

--- a/src/TinyEditor.php
+++ b/src/TinyEditor.php
@@ -199,7 +199,7 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function getToolbar(): string
     {
-        $toolbar = 'undo redo removeformat | styles | bold italic | rtl ltr | alignjustify alignright aligncenter alignleft | numlist bullist outdent indent accordion | forecolor backcolor | blockquote | link anchor codesample | image media | table | charmap emoticons hr | pagebreak nonbreaking | visualblocks visualchars | code wordcount | fullscreen preview print';
+        $toolbar = 'undo redo removeformat | styles | bold italic | rtl ltr | alignjustify alignright aligncenter alignleft | numlist bullist outdent indent accordion | forecolor backcolor | blockquote table toc hr | image link anchor media codesample emoticons | visualblocks print preview wordcount fullscreen help';
         if ($this->isSimple()) {
             $toolbar = 'removeformat | bold italic | rtl ltr | link emoticons';
         }
@@ -233,7 +233,7 @@ class TinyEditor extends Field implements Contracts\CanBeLengthConstrained
 
     public function getPlugins(): string
     {
-        $plugins = 'accordion autoresize codesample directionality advlist autolink link image lists charmap preview anchor pagebreak searchreplace wordcount visualblocks visualchars code fullscreen media table emoticons hr nonbreaking';
+        $plugins = 'accordion autoresize codesample directionality advlist autolink link image lists charmap preview anchor pagebreak searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media table emoticons help';
 
         if ($this->isSimple()) {
             $plugins = 'autoresize directionality emoticons link wordcount';


### PR DESCRIPTION
## Summary
This adds validation before persisting TinyEditor uploaded attachments from Livewire temporary storage.

`TinyEditor::setUp()` currently walks `<img>` tags in the submitted HTML, resolves the `data-id` back to a temporary upload, and then calls `saveUploadedFileAttachment()` directly. That means a crafted request can reference a non-image temporary upload through an `<img>` tag and have it persisted as an editor attachment.

This patch adds two guards before saving the attachment:
- require the uploaded file MIME type to start with `image/`
- require `getimagesize()` to succeed on the uploaded file

## Why this matters
Without these checks, the code path trusts that any temporary upload referenced by an `<img>` element is actually an image. In practice, that allows non-image files to move from temporary upload storage into the configured attachment storage if the request payload is manipulated.

## Validation
- `php -l src/TinyEditor.php`

This patch is based on a local security fix already in production use.
